### PR TITLE
DCO-9746 Added python3-apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND="noninteractive";\
     apt-get -y update; \
     apt-get -y install tzdata; \
     apt-get -y install systemd systemd-sysv; \
-    apt-get -y install python3.8 python3-pip sudo curl wget gzip tar less; \
+    apt-get -y install python3.8 python3-pip python3-apt sudo curl wget gzip tar less; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
     cd /lib/systemd/system/sysinit.target.wants/; \
     ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1; \


### PR DESCRIPTION
When running Molecule tests there is always a warning that python3-apt had to be installed as a missing dependency.

Need to add it to the image to get rid of the warning.

Signed-off-by: Mark A. Olson <mark.a.olson@intel.com>